### PR TITLE
Send service file to email

### DIFF
--- a/openlp/createServiceFile.php
+++ b/openlp/createServiceFile.php
@@ -187,7 +187,7 @@ class ServiceCreator {
 		$zip->close();
 	}
 
-    function sendTo($emailAddress) {
+    function sendTo($emailAddress, $fromEmailAddress) {
 		$file = tempnam("tmp", "zip");
         $this->saveService($file);
 
@@ -201,7 +201,7 @@ class ServiceCreator {
         $eol = PHP_EOL;
 
         // main header (multipart mandatory)
-        $headers = "From: b-dur@b-dur.dk" . $eol;
+        $headers = "From: " . $fromEmailAddress . $eol;
         $headers .= "MIME-Version: 1.0" . $eol;
         $headers .= "Content-Type: multipart/mixed; boundary=\"" . $separator . "\"" . $eol;
         $headers .= "Content-Transfer-Encoding: 7bit" . $eol;
@@ -253,8 +253,8 @@ if ($eventId) {
 	$content->insertAllSongs();
 }
 
-if($_GET['email']){
-    $content->sendTo($_GET['email']);
+if($_GET['email']) {
+    $content->sendTo($_GET['email'], $WEBMASTER_EMAIL);
 } else {
     echo $content->returnService();
 }

--- a/openlp/createServiceFile.php
+++ b/openlp/createServiceFile.php
@@ -253,7 +253,11 @@ if ($eventId) {
 	$content->insertAllSongs();
 }
 
-echo $content->returnService();
+if($_GET['email']){
+    $content->sendTo($_GET['email']);
+} else {
+    echo $content->returnService();
+}
 
 closeDB();
 

--- a/openlp/createServiceFile.php
+++ b/openlp/createServiceFile.php
@@ -169,11 +169,7 @@ class ServiceCreator {
 	
 	function returnService() {
 		$file = tempnam("tmp", "zip");
-		$zip = new ZipArchive();
-		// Zip will open and overwrite the file, rather than try to read it.
-		$zip->open($file, ZipArchive::OVERWRITE);
-		$zip->addFromString('service.osj', $this->getJSON());
-		$zip->close();
+        $this->saveService($file);
 		// Stream the file to the client
 		header("Content-Type: application/octet-stream");
 		header("Content-Length: " . filesize($file));

--- a/openlp/createServiceFile.php
+++ b/openlp/createServiceFile.php
@@ -186,10 +186,49 @@ class ServiceCreator {
 		$zip->addFromString('service.osj', $this->getJSON());
 		$zip->close();
 	}
-	
+
+    function sendTo($emailAddress) {
+		$file = tempnam("tmp", "zip");
+        $this->saveService($file);
+
+        $content = file_get_contents($file);
+        $content = chunk_split(base64_encode($content));
+
+        // a random hash will be necessary to send mixed content
+        $separator = md5(time());
+
+        // carriage return type (we use a PHP end of line constant)
+        $eol = PHP_EOL;
+
+        // main header (multipart mandatory)
+        $headers = "From: b-dur@b-dur.dk" . $eol;
+        $headers .= "MIME-Version: 1.0" . $eol;
+        $headers .= "Content-Type: multipart/mixed; boundary=\"" . $separator . "\"" . $eol;
+        $headers .= "Content-Transfer-Encoding: 7bit" . $eol;
+        $headers .= "This is a MIME encoded message." . $eol;
+
+        // message
+        $headers .= "--" . $separator . $eol;
+        $headers .= "Content-Type: text/plain; charset=\"iso-8859-1\"" . $eol;
+        $headers .= "Content-Transfer-Encoding: 8bit" . $eol;
+        $headers .= "Dagens program" . $eol;
+
+        // attachment
+        $headers .= "--" . $separator . $eol;
+        $headers .= "Content-Type: application/octet-stream; name=\"".$this->serviceName."\"" . $eol;
+        $headers .= "Content-Transfer-Encoding: base64" . $eol;
+        $headers .= "Content-Disposition: attachment" . $eol;
+        $headers .= $content . $eol;
+        $headers .= "--" . $separator . "--";
+
+        //SEND Mail
+        if (mail($emailAddress, "Dagens program", "", $headers)) {
+            echo "mail send ... OK"; // or use booleans here
+        } else {
+            echo "mail send ... ERROR!";
+        }
+    }
 }
-
-
 
 $content = new ServiceCreator();
 


### PR DESCRIPTION
Extended the CreateServiceFile to accept email address via query param, so instead of downloading the file the file will be sent as an email with an attachment.