### PR TITLE
Newer php doesnt allow everything defined in email headers

### DIFF
--- a/openlp/createAndSendUpcomingEvent.php
+++ b/openlp/createAndSendUpcomingEvent.php
@@ -24,10 +24,15 @@ $query = "SELECT ProgramID FROM Program where Dato = '" . $date . "'";
 try {
     openDB();
     $result = doSQLQuery($query);
+    $count = 0;
     while ($line = db_fetch_array($result)) {
+        $count = $count + 1;
         $eventId = $line["ProgramID"];
         $service = new ServiceCreator();
         $service->createFromEventId($eventId);
+        if($count > 1) {
+            $service->serviceName = str_replace(".osz", "-" . $count . ".osz", $service->serviceName);
+        }
         $service->sendTo($email, $WEBMASTER_EMAIL);
     }
 } finally {

--- a/openlp/serviceCreator.php
+++ b/openlp/serviceCreator.php
@@ -213,7 +213,7 @@ class ServiceCreator {
         $headers .= "This is a MIME encoded message." . $eol;
 
         // message
-        $message .= "--" . $separator . $eol;
+        $message = "--" . $separator . $eol;
         $message .= "Content-Type: text/plain; charset=\"iso-8859-1\"" . $eol;
         $message .= "Content-Transfer-Encoding: 8bit" . $eol;
         $message .= "Dagens program" . $eol;

--- a/openlp/serviceCreator.php
+++ b/openlp/serviceCreator.php
@@ -213,21 +213,21 @@ class ServiceCreator {
         $headers .= "This is a MIME encoded message." . $eol;
 
         // message
-        $headers .= "--" . $separator . $eol;
-        $headers .= "Content-Type: text/plain; charset=\"iso-8859-1\"" . $eol;
-        $headers .= "Content-Transfer-Encoding: 8bit" . $eol;
-        $headers .= "Dagens program" . $eol;
+        $message .= "--" . $separator . $eol;
+        $message .= "Content-Type: text/plain; charset=\"iso-8859-1\"" . $eol;
+        $message .= "Content-Transfer-Encoding: 8bit" . $eol;
+        $message .= "Dagens program" . $eol;
 
         // attachment
-        $headers .= "--" . $separator . $eol;
-        $headers .= "Content-Type: application/octet-stream; name=\"".$this->serviceName."\"" . $eol;
-        $headers .= "Content-Transfer-Encoding: base64" . $eol;
-        $headers .= "Content-Disposition: attachment" . $eol;
-        $headers .= $content . $eol;
-        $headers .= "--" . $separator . "--";
+        $message .= "--" . $separator . $eol;
+        $message .= "Content-Type: application/octet-stream; name=\"".$this->serviceName."\"" . $eol;
+        $message .= "Content-Transfer-Encoding: base64" . $eol;
+        $message .= "Content-Disposition: attachment" . $eol;
+        $message .= $content . $eol;
+        $message .= "--" . $separator . "--";
 
         //SEND Mail
-        if (mail($emailAddress, "Dagens program", "", $headers)) {
+        if (mail($emailAddress, "Dagens program", $message, $headers)) {
             echo "mail send ... OK"; // or use booleans here
         } else {
             echo "mail send ... ERROR!";

--- a/openlp/serviceCreator.php
+++ b/openlp/serviceCreator.php
@@ -221,9 +221,9 @@ class ServiceCreator {
         // attachment
         $message .= "--" . $separator . $eol;
         $message .= "Content-Type: application/octet-stream; name=\"".$this->serviceName."\"" . $eol;
-        $message .= "Content-Transfer-Encoding: base64" . $eol;
-        $message .= "Content-Disposition: attachment" . $eol;
-        $message .= $content . $eol;
+        $message .= "Content-Disposition: attachment; filename=\"".$this->serviceName."\"" . $eol;
+        $message .= "Content-Transfer-Encoding: base64" . $eol . $eol;
+        $message .= $content;
         $message .= "--" . $separator . "--";
 
         //SEND Mail


### PR DESCRIPTION
When the code came out to the server the php mail method failed. This is due to mismatch of php versions from local development and hosted environment.
PHP version on server has a more strict validation of content sent with the email method. E.g. can attachment not be defined in the header.
